### PR TITLE
avcodec/nvenc: use framerate if available

### DIFF
--- a/libavcodec/nvenc.c
+++ b/libavcodec/nvenc.c
@@ -1199,8 +1199,13 @@ static av_cold int nvenc_setup_encoder(AVCodecContext *avctx)
     ctx->init_encode_params.darHeight = dh;
     ctx->init_encode_params.darWidth = dw;
 
-    ctx->init_encode_params.frameRateNum = avctx->time_base.den;
-    ctx->init_encode_params.frameRateDen = avctx->time_base.num * avctx->ticks_per_frame;
+    if (avctx->framerate.num > 0 && avctx->framerate.den > 0) {
+        ctx->init_encode_params.frameRateNum = avctx->framerate.num;
+        ctx->init_encode_params.frameRateDen = avctx->framerate.den;
+    } else {
+        ctx->init_encode_params.frameRateNum = avctx->time_base.den;
+        ctx->init_encode_params.frameRateDen = avctx->time_base.num * avctx->ticks_per_frame;
+    }
 
     ctx->init_encode_params.enableEncodeAsync = 0;
     ctx->init_encode_params.enablePTD = 1;


### PR DESCRIPTION
Cherry-pick a bug-fix commit from upstream https://github.com/FFmpeg/FFmpeg/commit/b18fd2b95b2fea10f0b5381333a1b4c032f010bc

This is needed for https://github.com/livepeer/lpms/issues/232 