### PR TITLE
Fix Mpeg7 signature result issue

### DIFF
--- a/doc/filters.texi
+++ b/doc/filters.texi
@@ -13005,6 +13005,95 @@ lut2='if(lt(x,y),0,if(gt(x,y),pow(2,bdx)-1,pow(2,bdx-1))):if(lt(x,y),0,if(gt(x,y
 @end example
 @end itemize
 
+@section lvpdnn
+
+Inference the content in the input image/video by applying the lvpdnn methods based on
+convolutional neural networks. Supported models:
+
+TensorFlow model files(.pb)
+
+The filter accepts the following options:
+
+@table @option
+@item filter_type
+Specify which filter to use. This option accepts the following values:
+
+@table @samp
+@item lvpclassify
+lvpclassify filter. To conduct lvpclassify filter, you need to use a classify model.
+
+@item lvpodetect
+lvpodetect filter. To conduct object detect filter, you need to use a object detect model.
+@end table
+
+Default value is @samp{lvpclassify}.
+
+@item dnn_backend
+Specify which DNN backend to use for model loading and execution. This option accepts
+the following values:
+
+@table @samp
+@item native
+Native implementation of DNN loading and execution.
+
+@item tensorflow
+TensorFlow backend. To enable this backend you
+need to install the TensorFlow for C library (see
+@url{https://www.tensorflow.org/install/install_c}) and configure FFmpeg with
+@code{--enable-libtensorflow}
+@end table
+
+Default value is @samp{tensorflow}.
+
+@item model
+Set path to model file specifying network architecture and its parameters.
+Note that different backends use different file formats. TensorFlow can load files for only its format.
+
+@item input
+Set the input name of the dnn network.
+
+@item output
+Set the output name of the dnn network.
+
+@item sample
+Set the sample rate for inference.
+
+@item threshold
+Set the threshold for inference.
+
+@item log
+Set the log file path for save inference results.
+
+@end table
+
+@itemize
+@item
+Software transcoding:
+@example
+ffmpeg -i input.mp4 -vf lvpdnn=model=tmodel.pb:input=input:output=outshape:sample=1:threshold=0.5:log=outlog.txt out.mp4
+@end example
+
+@item
+Hardware transcoding:
+@example
+ffmpeg -vsync 0 -hwaccel cuvid -c:v h264_cuvid -i input.mp4 -c:a copy -vf lvpdnn=model=tmodel.pb:input=input:output=outshape:sample=1:threshold=0.5:log=outlog.txt -c:v h264_nvenc -b:v 5M out.mp4
+@end example
+
+@item
+Mixed transcoding:
+@example
+ffmpeg -vsync 0 -c:v h264_cuvid -i input.mp4 -vf lvpdnn=model=tmodel.pb:input=input:output=outshape:sample=1:threshold=0.5:log=outlog.txt -c:v h264_nvenc out.mp4
+@end example
+
+@item
+ffprobe example:
+@example
+ffprobe -show_entries frame_tags=lavfi.lvpdnn.text -f lavfi -i "movie=input.mp4,lvpdnn=model=tmodel.pb:input=input:output=outshape:sample=1:threshold=5.0"  > lvptext.txt
+@end example
+
+@end itemize
+
+
 @section maskedclamp
 
 Clamp the first input stream with the second input and third input stream.

--- a/libavcodec/nvenc.c
+++ b/libavcodec/nvenc.c
@@ -2262,3 +2262,8 @@ int ff_nvenc_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
 
     return 0;
 }
+
+av_cold void ff_nvenc_encode_flush(AVCodecContext *avctx)
+{
+    ff_nvenc_send_frame(avctx, NULL);
+}

--- a/libavcodec/nvenc.h
+++ b/libavcodec/nvenc.h
@@ -214,6 +214,8 @@ int ff_nvenc_receive_packet(AVCodecContext *avctx, AVPacket *pkt);
 int ff_nvenc_encode_frame(AVCodecContext *avctx, AVPacket *pkt,
                           const AVFrame *frame, int *got_packet);
 
+void ff_nvenc_encode_flush(AVCodecContext *avctx);
+
 extern const enum AVPixelFormat ff_nvenc_pix_fmts[];
 
 #endif /* AVCODEC_NVENC_H */

--- a/libavcodec/nvenc_h264.c
+++ b/libavcodec/nvenc_h264.c
@@ -240,6 +240,7 @@ AVCodec ff_h264_nvenc_encoder = {
     .receive_packet = ff_nvenc_receive_packet,
     .encode2        = ff_nvenc_encode_frame,
     .close          = ff_nvenc_encode_close,
+    .flush          = ff_nvenc_encode_flush,
     .priv_data_size = sizeof(NvencContext),
     .priv_class     = &h264_nvenc_class,
     .defaults       = defaults,

--- a/libavcodec/nvenc_hevc.c
+++ b/libavcodec/nvenc_hevc.c
@@ -198,6 +198,7 @@ AVCodec ff_hevc_nvenc_encoder = {
     .receive_packet = ff_nvenc_receive_packet,
     .encode2        = ff_nvenc_encode_frame,
     .close          = ff_nvenc_encode_close,
+    .flush          = ff_nvenc_encode_flush,
     .priv_data_size = sizeof(NvencContext),
     .priv_class     = &hevc_nvenc_class,
     .defaults       = defaults,

--- a/libavfilter/Makefile
+++ b/libavfilter/Makefile
@@ -308,6 +308,7 @@ OBJS-$(CONFIG_MINTERPOLATE_FILTER)           += vf_minterpolate.o motion_estimat
 OBJS-$(CONFIG_MIX_FILTER)                    += vf_mix.o framesync.o
 OBJS-$(CONFIG_MPDECIMATE_FILTER)             += vf_mpdecimate.o
 OBJS-$(CONFIG_NEGATE_FILTER)                 += vf_lut.o
+OBJS-$(CONFIG_LVPDNN_FILTER)                 += vf_lvpdnn.o
 OBJS-$(CONFIG_NLMEANS_FILTER)                += vf_nlmeans.o
 OBJS-$(CONFIG_NLMEANS_OPENCL_FILTER)         += vf_nlmeans_opencl.o opencl.o opencl/nlmeans.o
 OBJS-$(CONFIG_NNEDI_FILTER)                  += vf_nnedi.o

--- a/libavfilter/allfilters.c
+++ b/libavfilter/allfilters.c
@@ -278,6 +278,7 @@ extern AVFilter ff_vf_lut2;
 extern AVFilter ff_vf_lut3d;
 extern AVFilter ff_vf_lutrgb;
 extern AVFilter ff_vf_lutyuv;
+extern AVFilter ff_vf_lvpdnn;
 extern AVFilter ff_vf_maskedclamp;
 extern AVFilter ff_vf_maskedmax;
 extern AVFilter ff_vf_maskedmerge;

--- a/libavfilter/dnn/dnn_backend_tf.c
+++ b/libavfilter/dnn/dnn_backend_tf.c
@@ -127,8 +127,9 @@ static DNNReturnType get_input_tf(void *model, DNNData *input, const char *input
     }
     TF_DeleteStatus(status);
 
-    // currently only NHWC is supported
-    av_assert0(dims[0] == 1);
+    //currently only NHWC is supported
+    //some case is = -1
+    //av_assert0(dims[0] == 1);    
     input->height = dims[1];
     input->width = dims[2];
     input->channels = dims[3];
@@ -197,6 +198,11 @@ static DNNReturnType set_input_output_tf(void *model, DNNData *input, const char
     }
 
     sess_opts = TF_NewSessionOptions();
+    // protobuf data for auto memory gpu_options.allow_growth=True and gpu_options.visible_device_list="0" 
+	uint8_t config[7] = { 0x32, 0x5, 0x20, 0x1, 0x2a, 0x01, 0x30 }; 
+	TF_SetConfig(sess_opts, (void*)config, 7, tf_model->status);
+
+
     tf_model->session = TF_NewSession(tf_model->graph, sess_opts, tf_model->status);
     TF_DeleteSessionOptions(sess_opts);
     if (TF_GetCode(tf_model->status) != TF_OK)

--- a/libavfilter/signature_lookup.c
+++ b/libavfilter/signature_lookup.c
@@ -200,6 +200,7 @@ static MatchingInfo* get_matching_parameters(AVFilterContext *ctx, SignatureCont
     /* initialize houghspace */
     for (i = 0; i < MAX_FRAMERATE; i++) {
         hspace[i] = av_malloc_array(2 * HOUGH_MAX_OFFSET + 1, sizeof(hspace_elem));
+		memset(hspace[i], 0x00, sizeof(hspace_elem) * (2 * HOUGH_MAX_OFFSET + 1));
         for (j = 0; j < HOUGH_MAX_OFFSET; j++) {
             hspace[i][j].score = 0;
             hspace[i][j].dist = 99999;

--- a/libavfilter/vf_lvpdnn.c
+++ b/libavfilter/vf_lvpdnn.c
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) 2020 oscar
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @file 
+ * implementing livepeer frame filter using deep convolutional networks. 
+ */
+
+#include "libavformat/avio.h"
+#include "libavutil/opt.h"
+#include "libavutil/pixdesc.h"
+#include "libavutil/avassert.h"
+#include "libavutil/imgutils.h"
+#include "libavutil/hwcontext.h"
+#include "libavutil/hwcontext_internal.h"
+#include "libswscale/swscale.h"
+#include "avfilter.h"
+#include "dnn_interface.h"
+#include "formats.h"
+#include "internal.h"
+
+
+typedef struct LVPDnnContext {
+    const AVClass *class;
+
+    int     filter_type;
+    char    *model_filename;
+    DNNBackendType backend_type;
+    char    *model_inputname;
+    char    *model_outputname;
+    int     sample_rate;
+    double  valid_threshold;
+    char    *log_filename;
+
+    DNNModule   *dnn_module;
+    DNNModel    *model;
+
+    // input & output of the model at execution time
+    DNNData input;
+    DNNData output;
+    
+    struct SwsContext   *sws_rgb_scale;
+    struct SwsContext   *sws_gray8_to_grayf32;
+
+    struct AVFrame      *swscaleframe;
+    struct AVFrame      *swframeforHW;
+
+    FILE                *logfile;
+    int                 framenum;
+    //
+    struct SwsContext   *sws_grayf32_to_gray8;    
+    int                 sws_uv_height;
+
+} LVPDnnContext;
+
+#define OFFSET(x) offsetof(LVPDnnContext, x)
+#define FLAGS AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM
+static const AVOption lvpdnn_options[] = {
+    { "filter_type", "filter type(inference/detect)",   OFFSET(filter_type),    AV_OPT_TYPE_INT,        { .i64 = 0 },    0, 1, FLAGS, "type" },
+    { "inference",   "inference filter flag",           0,                      AV_OPT_TYPE_CONST,      { .i64 = 0 },    0, 0, FLAGS, "type" },
+    { "detect",      "detect filter flag",              0,                      AV_OPT_TYPE_CONST,      { .i64 = 1 },    0, 0, FLAGS, "type" },
+    { "dnn_backend", "DNN backend",                OFFSET(backend_type),     AV_OPT_TYPE_INT,           { .i64 = 0 },    0, 1, FLAGS, "backend" },
+    { "native",      "native backend flag",        0,                        AV_OPT_TYPE_CONST,         { .i64 = 0 },    0, 0, FLAGS, "backend" },
+#if (CONFIG_LIBTENSORFLOW == 1)
+    { "tensorflow",  "tensorflow backend flag",    0,                        AV_OPT_TYPE_CONST,         { .i64 = 1 },    0, 0, FLAGS, "backend" },
+#endif
+    { "model",       "path to model file",          OFFSET(model_filename),   AV_OPT_TYPE_STRING,       { .str = NULL }, 0, 0, FLAGS },
+    { "input",       "input name of the model",     OFFSET(model_inputname),  AV_OPT_TYPE_STRING,       { .str = NULL }, 0, 0, FLAGS },
+    { "output",      "output name of the model",    OFFSET(model_outputname), AV_OPT_TYPE_STRING,       { .str = NULL }, 0, 0, FLAGS },
+    { "sample","detector one every sample frames",  OFFSET(sample_rate),    AV_OPT_TYPE_INT,            { .i64 = 1   },  0, 2000, FLAGS },
+    { "threshold",  "threshold for verify",         OFFSET(valid_threshold),  AV_OPT_TYPE_DOUBLE,       { .dbl = 0.5 },  0, 2, FLAGS },
+    { "log",         "path name of the log",        OFFSET(log_filename), AV_OPT_TYPE_STRING,           { .str = NULL }, 0, 0, FLAGS },    
+    { NULL }
+};
+
+AVFILTER_DEFINE_CLASS(lvpdnn);
+
+static av_cold int init(AVFilterContext *context)
+{
+    LVPDnnContext *ctx = context->priv;
+
+    if (!ctx->model_filename) {
+        av_log(ctx, AV_LOG_ERROR, "model file for network is not specified\n");
+        return AVERROR(EINVAL);
+    }
+    if (!ctx->model_inputname) {
+        av_log(ctx, AV_LOG_ERROR, "input name of the model network is not specified\n");
+        return AVERROR(EINVAL);
+    }
+    if (!ctx->model_outputname) {
+        av_log(ctx, AV_LOG_ERROR, "output name of the model network is not specified\n");
+        return AVERROR(EINVAL);
+    }
+
+    if (!ctx->log_filename) {
+        av_log(ctx, AV_LOG_INFO, "output file for log is not specified\n");
+        //return AVERROR(EINVAL);
+    }
+
+    ctx->backend_type = 1;
+    ctx->dnn_module = ff_get_dnn_module(ctx->backend_type);
+    if (!ctx->dnn_module) {
+        av_log(ctx, AV_LOG_ERROR, "could not create DNN module for requested backend\n");
+        return AVERROR(ENOMEM);
+    }
+    if (!ctx->dnn_module->load_model) {
+        av_log(ctx, AV_LOG_ERROR, "load_model for network is not specified\n");
+        return AVERROR(EINVAL);
+    }
+
+    ctx->model = (ctx->dnn_module->load_model)(ctx->model_filename);
+    if (!ctx->model) {
+        av_log(ctx, AV_LOG_ERROR, "could not load DNN model\n");
+        return AVERROR(EINVAL);
+    }
+
+    if(ctx->log_filename){        
+        ctx->logfile = fopen(ctx->log_filename, "w");
+    }
+    else{        
+        ctx->logfile = NULL;
+    }
+
+    ctx->framenum = 0;
+
+    return 0;
+}
+
+static int query_formats(AVFilterContext *context)
+{
+    static const enum AVPixelFormat pix_fmts[] = {
+        AV_PIX_FMT_RGB24, AV_PIX_FMT_BGR24,AV_PIX_FMT_GRAY8, AV_PIX_FMT_GRAYF32,
+        AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUV422P, AV_PIX_FMT_YUV444P,
+        AV_PIX_FMT_YUV410P, AV_PIX_FMT_YUV411P,
+        AV_PIX_FMT_CUDA,AV_PIX_FMT_NONE
+    };
+    AVFilterFormats *fmts_list = ff_make_format_list(pix_fmts);
+    return ff_set_common_formats(context, fmts_list);
+}
+
+static int prepare_sws_context(AVFilterLink *inlink)
+{
+    int result = 0;
+    enum AVPixelFormat fmt = inlink->format;
+    AVFilterContext *context    = inlink->dst;
+    LVPDnnContext *ctx = context->priv;    
+    DNNDataType input_dt  = ctx->input.dt; 
+
+    //check hwframe 
+    if (inlink->hw_frames_ctx)
+    {
+        enum AVPixelFormat *formats;
+
+        result = av_hwframe_transfer_get_formats(inlink->hw_frames_ctx,
+                                            AV_HWFRAME_TRANSFER_DIRECTION_FROM,
+                                            &formats, 0);
+        if(result <0 ){
+            av_log(ctx, AV_LOG_ERROR, "could not find HW Pixelformat for scale\n");
+            return result;
+        }
+
+        fmt = formats[0];            
+        av_freep(&formats);
+    }
+
+    av_assert0(input_dt == DNN_FLOAT);     
+
+    ctx->sws_rgb_scale = sws_getContext(inlink->w, inlink->h, fmt,
+                                            ctx->input.width, ctx->input.height, AV_PIX_FMT_RGB24,
+                                            SWS_BILINEAR, NULL, NULL, NULL);
+
+    ctx->sws_gray8_to_grayf32 = sws_getContext(ctx->input.width*3,
+                                                ctx->input.height,
+                                                AV_PIX_FMT_GRAY8,
+                                                ctx->input.width*3,
+                                                ctx->input.height,
+                                                AV_PIX_FMT_GRAYF32,
+                                                0, NULL, NULL, NULL);  
+
+  
+
+    if(ctx->sws_rgb_scale == 0 || ctx->sws_gray8_to_grayf32 == 0)
+    {
+        av_log(ctx, AV_LOG_ERROR, "could not create scale context\n");
+        return AVERROR(ENOMEM);
+    }
+
+    ctx->swscaleframe = av_frame_alloc();
+    if (!ctx->swscaleframe)
+        return AVERROR(ENOMEM);
+
+    ctx->swscaleframe->format = AV_PIX_FMT_RGB24;
+    ctx->swscaleframe->width  = ctx->input.width;
+    ctx->swscaleframe->height = ctx->input.height;
+    result = av_frame_get_buffer(ctx->swscaleframe, 0);
+    if (result < 0) {
+        av_frame_free(&ctx->swscaleframe);
+        return result;
+    }
+
+    if (inlink->hw_frames_ctx){
+        ctx->swframeforHW = av_frame_alloc();
+
+        if (!ctx->swframeforHW)
+        return AVERROR(ENOMEM);
+    }
+
+    return 0;
+}
+static int config_input(AVFilterLink *inlink)
+{
+    AVFilterContext *context     = inlink->dst;
+    LVPDnnContext *ctx = context->priv;
+    DNNReturnType result;
+    DNNData model_input;
+    int check;    
+
+    result = ctx->model->get_input(ctx->model->model, &model_input, ctx->model_inputname);
+    if (result != DNN_SUCCESS) {
+        av_log(ctx, AV_LOG_ERROR, "could not get input from the model\n");
+        return AVERROR(EIO);
+    }
+
+    ctx->input.width    = model_input.width;
+    ctx->input.height   = model_input.height;
+    ctx->input.channels = model_input.channels;
+    ctx->input.dt = model_input.dt;
+    
+    check = prepare_sws_context(inlink);
+    if (check != 0) {
+        av_log(ctx, AV_LOG_ERROR, "could not create scale context for the model\n");
+        return AVERROR(EIO);
+    }
+
+    result = (ctx->model->set_input_output)(ctx->model->model,
+                                        &ctx->input, ctx->model_inputname,
+                                        (const char **)&ctx->model_outputname, 1);
+    
+
+    if (result != DNN_SUCCESS) {
+        av_log(ctx, AV_LOG_ERROR, "could not set input and output for the model\n");
+        return AVERROR(EIO);
+    }
+
+    return 0;
+}
+
+
+static int config_output(AVFilterLink *outlink)
+{
+    AVFilterContext *context = outlink->src;
+    LVPDnnContext *ctx = context->priv;
+    DNNReturnType result;
+
+    // have a try run in case that the dnn model resize the frame
+    result = (ctx->dnn_module->execute_model)(ctx->model, &ctx->output, 1);
+    if (result != DNN_SUCCESS){
+        av_log(ctx, AV_LOG_ERROR, "failed to execute model\n");
+        return AVERROR(EIO);
+    }
+
+    return 0;
+}
+
+static int copy_from_frame_to_dnn(LVPDnnContext *ctx, const AVFrame *frame)
+{
+    av_assert0(ctx->swscaleframe != 0);
+    int bytewidth = av_image_get_linesize(ctx->swscaleframe->format, ctx->swscaleframe->width, 0);
+    DNNData *dnn_input = &ctx->input;
+
+    if(ctx->swframeforHW)
+    {
+        if(av_hwframe_transfer_data(ctx->swframeforHW, frame, 0) != 0)
+            return AVERROR(EIO);
+        
+        sws_scale(ctx->sws_rgb_scale, (const uint8_t **)ctx->swframeforHW->data, ctx->swframeforHW->linesize,
+                  0, ctx->swframeforHW->height, (uint8_t * const*)(&ctx->swscaleframe->data),
+                 ctx->swscaleframe->linesize);
+
+    }
+    else
+    {
+        sws_scale(ctx->sws_rgb_scale, (const uint8_t **)frame->data, frame->linesize,
+                  0, frame->height, (uint8_t * const*)(&ctx->swscaleframe->data),
+                  ctx->swscaleframe->linesize);
+    }
+
+
+    if (dnn_input->dt == DNN_FLOAT) {
+        sws_scale(ctx->sws_gray8_to_grayf32, (const uint8_t **)ctx->swscaleframe->data, ctx->swscaleframe->linesize,
+                    0, ctx->swscaleframe->height, (uint8_t * const*)(&dnn_input->data),
+                    (const int [4]){ctx->swscaleframe->width * 3 * sizeof(float), 0, 0, 0});
+    } else {
+        av_assert0(dnn_input->dt == DNN_UINT8);
+        av_image_copy_plane(dnn_input->data, bytewidth,
+                            ctx->swscaleframe->data[0], ctx->swscaleframe->linesize[0],
+                            bytewidth, ctx->swscaleframe->height);
+    }
+    
+    return 0;   
+}
+
+static int copy_from_dnn_to_frame(LVPDnnContext *ctx, AVFrame *frame)
+{
+    int bytewidth = av_image_get_linesize(frame->format, frame->width, 0);
+    DNNData *dnn_output = &ctx->output;
+
+    switch (frame->format) {
+    case AV_PIX_FMT_RGB24:
+    case AV_PIX_FMT_BGR24:
+        if (dnn_output->dt == DNN_FLOAT) {
+            sws_scale(ctx->sws_grayf32_to_gray8, (const uint8_t *[4]){(const uint8_t *)dnn_output->data, 0, 0, 0},
+                      (const int[4]){frame->width * 3 * sizeof(float), 0, 0, 0},
+                      0, frame->height, (uint8_t * const*)frame->data, frame->linesize);
+
+        } else {
+            av_assert0(dnn_output->dt == DNN_UINT8);
+            av_image_copy_plane(frame->data[0], frame->linesize[0],
+                                dnn_output->data, bytewidth,
+                                bytewidth, frame->height);
+        }
+        return 0;
+    case AV_PIX_FMT_GRAY8:
+        // it is possible that data type of dnn output is float32,
+        // need to add support for such case when needed.
+        av_assert0(dnn_output->dt == DNN_UINT8);
+        av_image_copy_plane(frame->data[0], frame->linesize[0],
+                            dnn_output->data, bytewidth,
+                            bytewidth, frame->height);
+        return 0;
+    case AV_PIX_FMT_GRAYF32:
+        av_assert0(dnn_output->dt == DNN_FLOAT);
+        av_image_copy_plane(frame->data[0], frame->linesize[0],
+                            dnn_output->data, bytewidth,
+                            bytewidth, frame->height);
+        return 0;
+    case AV_PIX_FMT_YUV420P:
+    case AV_PIX_FMT_YUV422P:
+    case AV_PIX_FMT_YUV444P:
+    case AV_PIX_FMT_YUV410P:
+    case AV_PIX_FMT_YUV411P:
+        sws_scale(ctx->sws_grayf32_to_gray8, (const uint8_t *[4]){(const uint8_t *)dnn_output->data, 0, 0, 0},
+                  (const int[4]){frame->width * sizeof(float), 0, 0, 0},
+                  0, frame->height, (uint8_t * const*)frame->data, frame->linesize);
+        return 0;
+    default:
+        return AVERROR(EIO);
+    }
+
+    return 0;
+}
+
+static int filter_frame(AVFilterLink *inlink, AVFrame *in)
+{
+    char slvpinfo[256] = {0,};
+    AVFilterContext *context  = inlink->dst;
+    AVFilterLink *outlink = context->outputs[0];
+    LVPDnnContext *ctx = context->priv;
+    DNNReturnType dnn_result;
+    AVDictionary **metadata = &in->metadata;
+
+    ctx->framenum ++;
+
+    if(ctx->sample_rate > 0 && ctx->framenum % ctx->sample_rate == 0)
+    {
+        copy_from_frame_to_dnn(ctx, in);
+
+        dnn_result = (ctx->dnn_module->execute_model)(ctx->model, &ctx->output, 1);
+        if (dnn_result != DNN_SUCCESS){
+            av_log(ctx, AV_LOG_ERROR, "failed to execute model\n");
+            av_frame_free(&in);
+            return AVERROR(EIO);
+        }
+
+        DNNData *dnn_output = &ctx->output;
+        float* pfdata = dnn_output->data;
+        int lendata = ctx->output.height;
+        //            
+        if(lendata >= 2 && pfdata[0] >= ctx->valid_threshold)
+        {
+            snprintf(slvpinfo, sizeof(slvpinfo), "probability %.2f", pfdata[0]);  
+           
+            av_dict_set(metadata, "lavfi.lvpdnn.text", slvpinfo, 0);
+            if(ctx->logfile)
+            {
+                fprintf(ctx->logfile,"%s\n",slvpinfo);                
+            }      
+        }
+        //for DEBUG
+        //av_log(0, AV_LOG_INFO, "frame contents seems like aaa as %s\n",slvpinfo);        
+    }
+
+    if(ctx->logfile && ctx->framenum % 20 == 0)
+        fflush(ctx->logfile);
+
+    return ff_filter_frame(outlink, in);   
+}
+
+static av_cold void uninit(AVFilterContext *ctx)
+{
+    LVPDnnContext *context = ctx->priv;
+
+    sws_freeContext(context->sws_rgb_scale);
+    sws_freeContext(context->sws_gray8_to_grayf32);
+    sws_freeContext(context->sws_grayf32_to_gray8);
+
+    if (context->dnn_module)
+        (context->dnn_module->free_model)(&context->model);
+
+    av_freep(&context->dnn_module);
+
+    if(context->swscaleframe)
+        av_frame_free(&context->swscaleframe);
+
+    if(context->swframeforHW)
+        av_frame_free(&context->swframeforHW);
+
+    if(context->log_filename && context->logfile)
+    {
+        fclose(context->logfile);        
+    }
+}
+
+static const AVFilterPad lvpdnn_inputs[] = {
+    {
+        .name         = "default",
+        .type         = AVMEDIA_TYPE_VIDEO,
+        .config_props = config_input,
+        .filter_frame = filter_frame,
+    },
+    { NULL }
+};
+
+static const AVFilterPad lvpdnn_outputs[] = {
+    {
+        .name = "default",
+        .type = AVMEDIA_TYPE_VIDEO,
+        .config_props  = config_output,
+    },
+    { NULL }
+};
+
+AVFilter ff_vf_lvpdnn = {
+    .name          = "lvpdnn",
+    .description   = NULL_IF_CONFIG_SMALL("Apply lvpdnn filter to the input."),
+    .priv_size     = sizeof(LVPDnnContext),
+    .init          = init,
+    .uninit        = uninit,
+    .query_formats = query_formats,
+    .inputs        = lvpdnn_inputs,
+    .outputs       = lvpdnn_outputs,
+    .priv_class    = &lvpdnn_class,
+};

--- a/lvpdiff.me
+++ b/lvpdiff.me
@@ -1,1 +1,0 @@
-build & execute lvpdiff filter

--- a/lvpdiff.me
+++ b/lvpdiff.me
@@ -1,0 +1,1 @@
+build & execute lvpdiff filter


### PR DESCRIPTION
**Motivation**

Sometimes, the detection result of whether two videos match is inconsistent.

**Why**

I am sure that there was a bug in the calculation of compare two signature values.
In [here](https://github.com/livepeer/FFmpeg/blob/1fdf06e14239e1aaa9ddfb648fa374ca3cb1b269/libavfilter/signature_lookup.c#L201), 2 * HOUGH_MAX_OFFSET + 1 hspace_elem structure array are created but initialized only HOUGH_MAX_OFFSET elements.
In the calculation of compare, used more array elements more than HOUGH_MAX_OFFSET.

**Testing**

The signature compare result is always the same.

ffmpeg -i test_cpu/test_cpu_P720p30fps16x9_2_0_15.ts -i test_gpu/test_gpu_P720p30fps16x9_2_0_15.ts -filter_complex "[0:v][1:v] signature=nb_inputs=2:detectmode=full" -map :v -f null -


