### PR TITLE
Fix Mpeg7 inconsistent signature comp result

### DIFF
--- a/libavfilter/signature_lookup.c
+++ b/libavfilter/signature_lookup.c
@@ -199,7 +199,7 @@ static MatchingInfo* get_matching_parameters(AVFilterContext *ctx, SignatureCont
 
     /* initialize houghspace */
     for (i = 0; i < MAX_FRAMERATE; i++) {
-        hspace[i] = av_malloc_array(2 * HOUGH_MAX_OFFSET + 1, sizeof(hspace_elem));
+        hspace[i] = av_mallocz_array(2 * HOUGH_MAX_OFFSET + 1, sizeof(hspace_elem));
         for (j = 0; j < HOUGH_MAX_OFFSET; j++) {
             hspace[i][j].score = 0;
             hspace[i][j].dist = 99999;


### PR DESCRIPTION
**Motivation**

Sometimes, the detection result of whether two videos match is inconsistent.

**Why**

I am sure that there was a bug in the calculation of compare two signature values.
In [here](https://github.com/livepeer/FFmpeg/blob/1fdf06e14239e1aaa9ddfb648fa374ca3cb1b269/libavfilter/signature_lookup.c#L201), 2 * HOUGH_MAX_OFFSET + 1 hspace_elem structure array are created but initialized only HOUGH_MAX_OFFSET elements.
In the calculation of compare, used more array elements than HOUGH_MAX_OFFSET.

**Testing**

The signature compare result is always the same.

ffmpeg -i test_cpu/test_cpu_P720p30fps16x9_2_0_15.ts -i test_gpu/test_gpu_P720p30fps16x9_2_0_15.ts -filter_complex "[0:v][1:v] signature=nb_inputs=2:detectmode=full" -map :v -f null -