### PR TITLE
libavfilter: check signature data for validity

### DIFF
--- a/libavfilter/vf_signature.c
+++ b/libavfilter/vf_signature.c
@@ -499,6 +499,9 @@ static int binary_import(uint8_t *buffer, int fileLength, StreamContext *sc)
     // Coarse signatures
     // numOfSegments = number of coarse signatures
     numOfSegments = get_bits_long(&bitContext, 32);
+    if (!numOfSegments) {
+        return -1;
+    }
 
     sc->coarsesiglist = (CoarseSignature*)av_calloc(numOfSegments, sizeof(CoarseSignature));
     if(sc->coarsesiglist == NULL) {


### PR DESCRIPTION
Check signature data for validity in `binary_import` function.
Without that passing zero buffer to `avfilter_compare_sign_bybuff` leads to memory corruption.
