### PR TITLE
return "No such device" instead of unknown error for the invalid GPU device number

### DIFF
--- a/libavutil/hwcontext_cuda.c
+++ b/libavutil/hwcontext_cuda.c
@@ -387,28 +387,36 @@ static int cuda_device_create(AVHWDeviceContext *device_ctx,
     if (device)
         device_idx = strtol(device, NULL, 0);
 
-    if (cuda_device_init(device_ctx) < 0)
+    if (cuda_device_init(device_ctx) < 0) {
+        ret = AVERROR_UNKNOWN; //return non retriable error
         goto error;
+    }
 
     cu = hwctx->internal->cuda_dl;
 
     ret = CHECK_CU(cu->cuInit(0));
-    if (ret < 0)
+    if (ret < 0) {
+        ret = AVERROR_UNKNOWN; //return non retriable error
         goto error;
+    }
 
     ret = CHECK_CU(cu->cuDeviceGet(&hwctx->internal->cuda_device, device_idx));
-    if (ret < 0)
+    if (ret < 0) {
+        ret = AVERROR(ENODEV); //return retriable error
         goto error;
+    }
 
     ret = cuda_context_init(device_ctx, flags);
-    if (ret < 0)
+    if (ret < 0) {
+        ret = AVERROR_UNKNOWN; //return non retriable error
         goto error;
+    }
 
     return 0;
 
 error:
     cuda_device_uninit(device_ctx);
-    return AVERROR_UNKNOWN;
+    return ret;
 }
 
 static int cuda_device_derive(AVHWDeviceContext *device_ctx,

--- a/libavutil/hwcontext_cuda.c
+++ b/libavutil/hwcontext_cuda.c
@@ -388,7 +388,7 @@ static int cuda_device_create(AVHWDeviceContext *device_ctx,
         device_idx = strtol(device, NULL, 0);
 
     if (cuda_device_init(device_ctx) < 0) {
-        ret = AVERROR_UNKNOWN; //return non retriable error
+        ret = AVERROR_UNKNOWN;
         goto error;
     }
 
@@ -396,19 +396,19 @@ static int cuda_device_create(AVHWDeviceContext *device_ctx,
 
     ret = CHECK_CU(cu->cuInit(0));
     if (ret < 0) {
-        ret = AVERROR_UNKNOWN; //return non retriable error
+        ret = AVERROR_UNKNOWN;
         goto error;
     }
 
     ret = CHECK_CU(cu->cuDeviceGet(&hwctx->internal->cuda_device, device_idx));
     if (ret < 0) {
-        ret = AVERROR(ENODEV); //return retriable error
+        ret = AVERROR(ENODEV);
         goto error;
     }
 
     ret = cuda_context_init(device_ctx, flags);
     if (ret < 0) {
-        ret = AVERROR_UNKNOWN; //return non retriable error
+        ret = AVERROR_UNKNOWN;
         goto error;
     }
 


### PR DESCRIPTION
When I try to test the GPU transcoding from [lpms#280](https://github.com/livepeer/lpms/pull/280), the test fails. If an invalid GPU device number (eg 9999) is entered, it will fail with an unknown error from ffmpeg. Returning a "No such device" error code instead of an unknown error should solve the problem.