### PR TITLE
fix panic for Mpeg7 signature compare 

### DIFF
--- a/libavfilter/vf_signature.c
+++ b/libavfilter/vf_signature.c
@@ -681,10 +681,10 @@ static int compare_signbuffer(uint8_t* signbuf1, int len1, uint8_t* signbuf2, in
         .streamcontexts = scontexts
     };
     if (binary_import(signbuf1, len1, &scontexts[0]) < 0 || binary_import(signbuf2, len2, &scontexts[1]) < 0) {
-        if(!scontexts[0].coarsesiglist) {
+        if(scontexts[0].coarsesiglist) {
             av_freep(&scontexts[0].coarsesiglist);
         }
-		if(!scontexts[1].coarsesiglist) {
+        if(scontexts[1].coarsesiglist) {
             av_freep(&scontexts[1].coarsesiglist);
         }
         av_log(NULL, AV_LOG_ERROR, "Could not create StreamContext from binary data for signature\n");


### PR DESCRIPTION
follow up to #[2175](https://github.com/livepeer/go-livepeer/issues/2175)


1.  review dangerous memory access code and [check ](https://github.com/livepeer/FFmpeg/blob/37b0e7e80582bd108cb2d2628592c86821505e98/libavfilter/vf_signature.c#L550)remain bits size while read buffer
2.  passed fuzzy [test](https://github.com/livepeer/lpms/pull/296) , thanks @darkdarkdragon 
3.  plus - [free](https://github.com/livepeer/FFmpeg/blob/37b0e7e80582bd108cb2d2628592c86821505e98/libavfilter/vf_signature.c#L684) remain memory when import function return fail
