### PR TITLE
Set frame similarity threshold to reduce fast verification fails 

### DIFF
--- a/libavfilter/vf_signature.c
+++ b/libavfilter/vf_signature.c
@@ -675,7 +675,7 @@ static int compare_signbuffer(uint8_t* signbuf1, int len1, uint8_t* signbuf2, in
         .filename = NULL,
         .thworddist = 9000,
         .thcomposdist = 60000,
-        .thl1 = 116,
+        .thl1 = 150,
         .thdi = 0,
         .thit = 0.5,
         .streamcontexts = scontexts


### PR DESCRIPTION
[Go-livepeer issue #2654](https://github.com/livepeer/go-livepeer/issues/2654)