### PR TITLE
Fix mathops.h to build with cuda 12.

### DIFF
--- a/libavcodec/x86/mathops.h
+++ b/libavcodec/x86/mathops.h
@@ -35,12 +35,20 @@
 static av_always_inline av_const int MULL(int a, int b, unsigned shift)
 {
     int rt, dummy;
+    if (__builtin_constant_p(shift))
     __asm__ (
         "imull %3               \n\t"
         "shrdl %4, %%edx, %%eax \n\t"
         :"=a"(rt), "=d"(dummy)
-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
+        :"a"(a), "rm"(b), "i"(shift & 0x1F)
     );
+    else
+        __asm__ (
+            "imull %3               \n\t"
+            "shrdl %4, %%edx, %%eax \n\t"
+            :"=a"(rt), "=d"(dummy)
+            :"a"(a), "rm"(b), "c"((uint8_t)shift)
+        );
     return rt;
 }
 
@@ -113,19 +121,31 @@ __asm__ volatile(\
 // avoid +32 for shift optimization (gcc should do that ...)
 #define NEG_SSR32 NEG_SSR32
 static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
+    if (__builtin_constant_p(s))
     __asm__ ("sarl %1, %0\n\t"
          : "+r" (a)
-         : "ic" ((uint8_t)(-s))
+         : "i" (-s & 0x1F)
     );
+    else
+        __asm__ ("sarl %1, %0\n\t"
+               : "+r" (a)
+               : "c" ((uint8_t)(-s))
+        );
     return a;
 }
 
 #define NEG_USR32 NEG_USR32
 static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
+    if (__builtin_constant_p(s))
     __asm__ ("shrl %1, %0\n\t"
          : "+r" (a)
-         : "ic" ((uint8_t)(-s))
+         : "i" (-s & 0x1F)
     );
+    else
+        __asm__ ("shrl %1, %0\n\t"
+               : "+r" (a)
+               : "c" ((uint8_t)(-s))
+        );
     return a;
 }
 


### PR DESCRIPTION
Patch forward referencing https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/509219/2/chromium/third_party/ffmpeg/libavcodec/x86/mathops.h to allow livepeer with CUDA 12 to build.

This fixes the following build time issue at commit 2e18d06966.

```bash
$ make
CC	libavdevice/avdevice.o
AR	libavdevice/libavdevice.a
CC	libavfilter/avfilter.o
CC	libavfilter/vf_signature.o
./libavcodec/x86/mathops.h: Assembler messages:
./libavcodec/x86/mathops.h:125: Error: operand type mismatch for `shr'
...
```

CUDA version:

```bash
$ /usr/local/cuda/bin/nvcc -V
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2023 NVIDIA Corporation
Built on Wed_Nov_22_10:17:15_PST_2023
Cuda compilation tools, release 12.3, V12.3.107
Build cuda_12.3.r12.3/compiler.33567101_0
```

Linked against CUDA 12 shared libraries:

```bash
$ ldd ./livepeer | grep cuda
	libnppig.so.12 => /usr/local/cuda/targets/x86_64-linux/lib/libnppig.so.12 (0x00007d4fa2200000)
	libnppicc.so.12 => /usr/local/cuda/targets/x86_64-linux/lib/libnppicc.so.12 (0x00007d4fa1800000)
	libnppc.so.12 => /usr/local/cuda/targets/x86_64-linux/lib/libnppc.so.12 (0x00007d4fa1000000)
```